### PR TITLE
Fix: showNext 값이 바뀔 때 답과 후보를 세팅 or 처음에 모두 세팅

### DIFF
--- a/src/pages/games/WordMemory.tsx
+++ b/src/pages/games/WordMemory.tsx
@@ -46,14 +46,11 @@ function WordMemory({
   );
 
   useEffect(() => {
-    if (isShowNext) {
-      setWords(answers);
-    } else {
-      setAnswers(answers);
-      setCandidates(
-        problemPool.map((v) => v.contents).sort(() => getRandomFloat() - 0.5),
-      );
-    }
+    setWords(answers);
+    setAnswers(answers);
+    setCandidates(
+      problemPool.map((v) => v.contents).sort(() => getRandomFloat() - 0.5),
+    );
   }, []);
 
   return (


### PR DESCRIPTION
### 문제 상황
```
useEffect(() => {
  if (showNext) {
    setWords(answers);
  } else {
    setAnswers(answers);
    setCandidates(
      problemPool.map((v) => v.contents).sort(() => getRandomFloat() - 0.5),
    );
  }
}, []);
```
- 후에 showNext 값이 사라진 상태에서 다시 보여질 컴포넌트에 대해 답과 후보가 세팅되지 않은 상태에서 표시되는 문제

### 해결 방안
1. 의존성에 showNext를 추가하여, showNext 값이 바뀌었을 때에서야 답과 후보를 세팅하는 방법
2. 처음 컴포넌트가 렌더링될 때 외울 단어, 답과 후보 모두를 세팅하는 방법

2번으로 수정