### PR TITLE
Design: 카드 매치 게임에서 카드 비율 조정

### DIFF
--- a/src/components/games/CardMatch.tsx
+++ b/src/components/games/CardMatch.tsx
@@ -40,13 +40,23 @@ const Card = styled.div`
   transform-style: preserve-3d;
 `;
 
-const FlipWrapper = styled.div`
+const FlipWrapper = styled.div<{ $difficulty: number }>`
   position: relative;
   width: 100%;
   height: 0;
   padding-bottom: 100%;
   @media screen and (min-width: 768px) and (max-height: 1079px) {
-    padding-bottom: 50%;
+    ${(props) => {
+      if (props.$difficulty === 1) {
+        return `padding-bottom: 50%;`;
+      }
+      if (props.$difficulty === 2) {
+        return `padding-bottom: 70%;`;
+      }
+      if (props.$difficulty === 3) {
+        return `padding-bottom: 120%;`;
+      }
+    }}
   }
   @media screen and (max-width: 767px) {
     padding-bottom: 150%;
@@ -75,6 +85,7 @@ const Front = styled.div<{ $status: boolean; $background: string }>`
   backface-visibility: hidden;
   background: url(${(props) => props.$background});
   background-size: cover;
+  background-position: center;
   transform: ${(props) =>
     props.$status ? 'rotateY(0deg)' : 'rotateY(180deg)'};
   border-radius: 1.5rem;

--- a/src/components/games/CardMatch.tsx
+++ b/src/components/games/CardMatch.tsx
@@ -44,7 +44,7 @@ const FlipWrapper = styled.div<{ $difficulty: number }>`
   position: relative;
   width: 100%;
   height: 0;
-  padding-bottom: 100%;
+  padding-bottom: ${(props) => (props.$difficulty === 3 ? '150%' : '100%')};
   @media screen and (min-width: 768px) and (max-height: 1079px) {
     ${(props) => {
       if (props.$difficulty === 1) {

--- a/src/pages/games/CardMatch.tsx
+++ b/src/pages/games/CardMatch.tsx
@@ -98,7 +98,7 @@ export default function CardMatch({
   return (
     <Container $difficulty={difficulty}>
       {mixedCards.map((card) => (
-        <FlipWrapper key={card.idx}>
+        <FlipWrapper key={card.idx} $difficulty={difficulty}>
           <Flip
             $status={card.status}
             $clickable={clickable}


### PR DESCRIPTION
# 스크린샷
<img width="250" alt="스크린샷 2023-11-07 오후 4 49 46" src="https://github.com/SWM-GGS/Brain-Vitamin-Frontend-Patient/assets/86469788/08dda3db-7f4f-4d3a-9eec-8ee222ed3ed7">
<img width="250" alt="스크린샷 2023-11-07 오후 4 48 41" src="https://github.com/SWM-GGS/Brain-Vitamin-Frontend-Patient/assets/86469788/f81b5be6-84f4-4c8e-8c70-d8ceafd33774">
<img width="250" alt="스크린샷 2023-11-07 오후 4 49 11" src="https://github.com/SWM-GGS/Brain-Vitamin-Frontend-Patient/assets/86469788/723cbe0e-bde3-4ca4-aba1-1aab5879ef21">

- 세로보다 가로가 더 긴 태블릿 해상도 특성상 모든 난도에서 세로가 더 긴 카드를 만들기 어려움
- 따라서 게임 프레임을 채울 정도의 크기까지 카드의 세로 길이를 늘림으로써 카드 비율 조정