### PR TITLE
Fix: 가족 커뮤니티 api 요청 시, 가족 고유번호가 아니라 id로 요청하도록 수정

### DIFF
--- a/src/pages/Family.tsx
+++ b/src/pages/Family.tsx
@@ -23,9 +23,7 @@ export type EmotionInfoDtoListProps = {
   };
 };
 function Family() {
-  const { accessToken, familyKey } = useSelector(
-    (state: RootState) => state.user,
-  );
+  const { accessToken, id } = useSelector((state: RootState) => state.user);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
   type PostPreviewDtoListProps = {
@@ -62,14 +60,14 @@ function Family() {
   }, []);
 
   useEffect(() => {
-    if (!familyKey) {
+    if (!id) {
       setLoading(false);
       return;
     }
     const getData = async () => {
       try {
         const { data } = await axios.get(
-          `${import.meta.env.VITE_API_URL}/patient/family-stories/${familyKey}`,
+          `${import.meta.env.VITE_API_URL}/patient/family-stories/${id}`,
           // `${import.meta.env.VITE_API_URL}/patient/family-stories/${1}`,
           {
             headers: {

--- a/src/pages/LogIn.tsx
+++ b/src/pages/LogIn.tsx
@@ -74,10 +74,11 @@ function LogIn() {
           openModal(data.message);
           return;
         }
-        const { name, nickname, fontSize, familyKey } =
+        const { id, name, nickname, fontSize, familyKey } =
           data.result.patientDetailDto;
         dispatch(
           userSlice.actions.setUser({
+            id,
             name,
             nickname,
             fontSize,

--- a/src/pages/NameSet.tsx
+++ b/src/pages/NameSet.tsx
@@ -45,13 +45,15 @@ function NameSet() {
         openModal(data.message);
         return;
       }
+      const { id, familyKey } = data.result.patientDetailDto;
       dispatch(
         userSlice.actions.setUser({
+          id,
           name,
           nickname,
           fontSize,
           phoneNumber: state.phoneNumber,
-          familyKey: data.result.patientDetailDto.familyKey,
+          familyKey,
           accessToken: data.result.tokenDto.accessTokenDto.accessToken,
         }),
       );

--- a/src/pages/Setting.tsx
+++ b/src/pages/Setting.tsx
@@ -38,6 +38,7 @@ function Setting() {
     localStorage.removeItem('accessToken');
     dispatch(
       userSlice.actions.setUser({
+        id: null,
         name: '',
         nickname: '',
         fontSize,

--- a/src/slices/user.ts
+++ b/src/slices/user.ts
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
+  id: null,
   name: '',
   nickname: '',
   phoneNumber: '',
@@ -15,6 +16,7 @@ const userSlice = createSlice({
   initialState,
   reducers: {
     setUser(state, action) {
+      state.id = action.payload.id;
       state.name = action.payload.name;
       state.nickname = action.payload.nickname;
       state.phoneNumber = action.payload.phoneNumber;


### PR DESCRIPTION
- 전역 상태에 id 추가하여, 로그인할 때나 회원가입할 때 저장
- 가족 커뮤니티 페이지 접근 시 해당 id로 api 요청